### PR TITLE
Adding OGLE_2011_BLG_0462 json

### DIFF
--- a/JSON/OGLE-2011-BLG-0462.json
+++ b/JSON/OGLE-2011-BLG-0462.json
@@ -1,0 +1,4 @@
+{"ID": {"Value": "OGLE-2011-BLG-0462"},
+ "M1": {"Value": "7.1", "Error": "1.3", "Ref": "2022ApJ...933L..23L"},
+ "Discovery Channel":{"Value": "Lensing", "Ref": "2022ApJ...933L..23L"},
+ "COMMENTS": {"Value": "None"}}


### PR DESCRIPTION
This json file contains the initial information for the lensing event OGLE-2011-BLG-0462. I've taken the masses from [Sahu et al. 2022](https://ui.adsabs.harvard.edu/abs/2022ApJ...933...83S/abstract ), but it should be added to the page that there is another mass measurement from [Lam et al.](https://ui.adsabs.harvard.edu/abs/2022ApJ...933L..23L/abstract).